### PR TITLE
feat(styles): add transparent windows controls

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -245,6 +245,24 @@
 
   window.addEventListener("resize", enhanceInterface);
   enhanceInterface();
+
+  // Set Window Control Zoom Variable
+  function handleTransparentWindows() {
+    Spicetify.Platform.PlayerAPI._prefs
+      .get({ key: "app.browser.zoom-level" })
+      .then((value) => {
+        const zoom = Number(value.entries["app.browser.zoom-level"].number);
+        console.log(zoom);
+      });
+
+    document.documentElement.style.setProperty(
+      "--windows-control-zoom",
+      window.outerWidth / window.innerWidth || 1
+    );
+  }
+
+  window.addEventListener("resize", handleTransparentWindows);
+  handleTransparentWindows();
 })();
 
 (function volumePercentage() {
@@ -649,4 +667,3 @@
     }
   });
 })();
-

--- a/src/user.css
+++ b/src/user.css
@@ -132,6 +132,17 @@
   font-weight: var(--bold-font-weight);
 }
 
+/* Transparent Windows Controls */
+body::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  z-index: 999;
+  backdrop-filter: brightness(2.12);
+  width: calc(135px / var(--windows-control-zoom, 1));
+  height: calc(48px / var(--windows-control-zoom, 1));
+}
+
 /* Scrollbars */
 .os-scrollbar-track {
   margin-bottom: calc(


### PR DESCRIPTION
## Purposes
First of all, i love your theme. 

This PR is a proposal to add transparent windows control for better visual consistency.
The code it self is not mine, i get it from spicetify discord [thread here](https://discord.com/channels/842219447716151306/1113028484349038593)


### Screenshot
![image](https://github.com/sanoojes/better-bloom/assets/34946363/90bcb5dc-b447-4371-aef9-bca2532bcbac)
